### PR TITLE
feat: add AWS keys variables

### DIFF
--- a/mutate.go
+++ b/mutate.go
@@ -82,6 +82,8 @@ func mutate(request v1beta1.AdmissionRequest) (v1beta1.AdmissionResponse, error)
 export MINIO_URL="http://minimal-tenant1-minio.minio:9000"
 export MINIO_ACCESS_KEY="{{ .Data.accessKeyId }}"
 export MINIO_SECRET_KEY="{{ .Data.secretAccessKey }}"
+export AWS_ACCESS_KEY_ID="{{ .Data.accessKeyId }}"
+export AWS_SECRET_ACCESS_KEY="{{ .Data.secretAccessKey }}"
 {{- end }}
 						`, roleName),
 			},
@@ -97,7 +99,7 @@ export MINIO_SECRET_KEY="{{ .Data.secretAccessKey }}"
 				"path": "/metadata/annotations/vault.hashicorp.com~1agent-inject-template-minio-minimal-tenant1.json",
 				"value": fmt.Sprintf(`
 {{- with secret "minio_minimal_tenant1/keys/%s" }}
-{"MINIO_URL":"http://minimal-tenant1-minio.minio:9000","MINIO_ACCESS_KEY":"{{ .Data.accessKeyId }}","MINIO_SECRET_KEY":"{{ .Data.secretAccessKey }}"}
+{"MINIO_URL":"http://minimal-tenant1-minio.minio:9000","MINIO_ACCESS_KEY":"{{ .Data.accessKeyId }}","MINIO_SECRET_KEY":"{{ .Data.secretAccessKey }}","AWS_ACCESS_KEY_ID":"{{ .Data.accessKeyId }}","AWS_SECRET_ACCESS_KEY":"{{ .Data.secretAccessKey }}"}
 {{- end }}
 						`, roleName),
 			},
@@ -116,6 +118,8 @@ export MINIO_SECRET_KEY="{{ .Data.secretAccessKey }}"
 export MINIO_URL="http://pachyderm-tenant1-minio.minio:9000"
 export MINIO_ACCESS_KEY="{{ .Data.accessKeyId }}"
 export MINIO_SECRET_KEY="{{ .Data.secretAccessKey }}"
+export AWS_ACCESS_KEY_ID="{{ .Data.accessKeyId }}"
+export AWS_SECRET_ACCESS_KEY="{{ .Data.secretAccessKey }}"
 {{- end }}
 						`, roleName),
 			},
@@ -131,7 +135,7 @@ export MINIO_SECRET_KEY="{{ .Data.secretAccessKey }}"
 				"path": "/metadata/annotations/vault.hashicorp.com~1agent-inject-template-minio-pachyderm-tenant1.json",
 				"value": fmt.Sprintf(`
 {{- with secret "minio_pachyderm_tenant1/keys/%s" }}
-{"MINIO_URL":"http://pachyderm-tenant1-minio.minio:9000","MINIO_ACCESS_KEY":"{{ .Data.accessKeyId }}","MINIO_SECRET_KEY":"{{ .Data.secretAccessKey }}"}
+{"MINIO_URL":"http://pachyderm-tenant1-minio.minio:9000","MINIO_ACCESS_KEY":"{{ .Data.accessKeyId }}","MINIO_SECRET_KEY":"{{ .Data.secretAccessKey }}","AWS_ACCESS_KEY_ID":"{{ .Data.accessKeyId }}","AWS_SECRET_ACCESS_KEY":"{{ .Data.secretAccessKey }}"}
 {{- end }}
 						`, roleName),
 			},
@@ -150,6 +154,8 @@ export MINIO_SECRET_KEY="{{ .Data.secretAccessKey }}"
 export MINIO_URL="http://premium-tenant1-minio.minio:9000"
 export MINIO_ACCESS_KEY="{{ .Data.accessKeyId }}"
 export MINIO_SECRET_KEY="{{ .Data.secretAccessKey }}"
+export AWS_ACCESS_KEY_ID="{{ .Data.accessKeyId }}"
+export AWS_SECRET_ACCESS_KEY="{{ .Data.secretAccessKey }}"
 {{- end }}
 						`, roleName),
 			},
@@ -165,7 +171,7 @@ export MINIO_SECRET_KEY="{{ .Data.secretAccessKey }}"
 				"path": "/metadata/annotations/vault.hashicorp.com~1agent-inject-template-minio-premium-tenant1.json",
 				"value": fmt.Sprintf(`
 {{- with secret "minio_premium_tenant1/keys/%s" }}
-{"MINIO_URL":"http://premium-tenant1-minio.minio:9000","MINIO_ACCESS_KEY":"{{ .Data.accessKeyId }}","MINIO_SECRET_KEY":"{{ .Data.secretAccessKey }}"}
+{"MINIO_URL":"http://premium-tenant1-minio.minio:9000","MINIO_ACCESS_KEY":"{{ .Data.accessKeyId }}","MINIO_SECRET_KEY":"{{ .Data.secretAccessKey }}","AWS_ACCESS_KEY_ID":"{{ .Data.accessKeyId }}","AWS_SECRET_ACCESS_KEY":"{{ .Data.secretAccessKey }}"}
 {{- end }}
 						`, roleName),
 			},


### PR DESCRIPTION
# What?

Adds the AWS key variables in addition to the existing MinIO variables.

# Why?

Some applications (`R`, `dvc`, etc) look for these environment variables, so setting them directly within the `source` command simplifies things for a bunch of applications.