### PR TITLE
DRAFT: feat: add mc config host add to the sourced file

### DIFF
--- a/mutate.go
+++ b/mutate.go
@@ -82,6 +82,8 @@ func mutate(request v1beta1.AdmissionRequest) (v1beta1.AdmissionResponse, error)
 export MINIO_URL="http://minimal-tenant1-minio.minio:9000"
 export MINIO_ACCESS_KEY="{{ .Data.accessKeyId }}"
 export MINIO_SECRET_KEY="{{ .Data.secretAccessKey }}"
+
+mc version > /dev/null 2>&1 && mc config host add minimal $MINIO_URL $MINIO_ACCESS_KEY $MINIO_SECRET_KEY || true
 {{- end }}
 						`, roleName),
 			},
@@ -116,6 +118,8 @@ export MINIO_SECRET_KEY="{{ .Data.secretAccessKey }}"
 export MINIO_URL="http://pachyderm-tenant1-minio.minio:9000"
 export MINIO_ACCESS_KEY="{{ .Data.accessKeyId }}"
 export MINIO_SECRET_KEY="{{ .Data.secretAccessKey }}"
+
+mc version > /dev/null 2>&1 && mc config host add pachyderm $MINIO_URL $MINIO_ACCESS_KEY $MINIO_SECRET_KEY || true
 {{- end }}
 						`, roleName),
 			},
@@ -150,6 +154,8 @@ export MINIO_SECRET_KEY="{{ .Data.secretAccessKey }}"
 export MINIO_URL="http://premium-tenant1-minio.minio:9000"
 export MINIO_ACCESS_KEY="{{ .Data.accessKeyId }}"
 export MINIO_SECRET_KEY="{{ .Data.secretAccessKey }}"
+
+mc version > /dev/null 2>&1 && mc config host add premium $MINIO_URL $MINIO_ACCESS_KEY $MINIO_SECRET_KEY || true
 {{- end }}
 						`, roleName),
 			},


### PR DESCRIPTION
I thought that this might be a good idea. At the moment users manually have to run source then config host add, and it seems like there'd be little harm in automating this process.

**I have not tested this change yet**, and am a little unsure what the process is to test this.