### PR TITLE
Add annotation to request credential inject

### DIFF
--- a/mutate.go
+++ b/mutate.go
@@ -45,7 +45,7 @@ func mutate(request v1beta1.AdmissionRequest) (v1beta1.AdmissionResponse, error)
 	}
 
 	// Inject Minio credentials into pod requesting credentials (condition: has add-default-minio-creds annotation)
-	if _, ok := pod.ObjectMeta.Annotations["add-default-minio-creds"]; ok {
+	if _, ok := pod.ObjectMeta.Annotations["data.statcan.gc.ca/inject-minio-creds"]; ok {
 		log.Printf("Found minio credential annotation on %s/%s", pod.Namespace, pod.Name)
 		shouldInject = true
 	}

--- a/mutate.go
+++ b/mutate.go
@@ -46,7 +46,7 @@ func mutate(request v1beta1.AdmissionRequest) (v1beta1.AdmissionResponse, error)
 
 	// Inject Minio credentials into pod requesting credentials (condition: has add-default-minio-creds annotation)
 	if _, ok := pod.ObjectMeta.Annotations["add-default-minio-creds"]; ok {
-		log.Printf("Found pod requesting default minio credentials %s/%s", pod.Namespace, pod.Name)
+		log.Printf("Found minio credential annotation on %s/%s", pod.Namespace, pod.Name)
 		shouldInject = true
 	}
 

--- a/mutate.go
+++ b/mutate.go
@@ -31,8 +31,8 @@ func mutate(request v1beta1.AdmissionRequest) (v1beta1.AdmissionResponse, error)
 
 	log.Printf("Check pod for notebook or workflow %s/%s", pod.Namespace, pod.Name)
 
-	// Inject Minio credentials into notebook pods (condition: has notebook-name label)
 	shouldInject := false
+	// Inject Minio credentials into notebook pods (condition: has notebook-name label)
 	if _, ok := pod.ObjectMeta.Labels["notebook-name"]; ok {
 		log.Printf("Found notebook name for %s/%s", pod.Namespace, pod.Name)
 		shouldInject = true
@@ -43,6 +43,13 @@ func mutate(request v1beta1.AdmissionRequest) (v1beta1.AdmissionResponse, error)
 		log.Printf("Found argo workflow name for %s/%s", pod.Namespace, pod.Name)
 		shouldInject = true
 	}
+
+	// Inject Minio credentials into pod requesting credentials (condition: has add-default-minio-creds annotation)
+	if _, ok := pod.ObjectMeta.Annotations["add-default-minio-creds"]; ok {
+		log.Printf("Found pod requesting default minio credentials %s/%s", pod.Namespace, pod.Name)
+		shouldInject = true
+	}
+
 
 	if shouldInject {
 		patch := v1beta1.PatchTypeJSONPatch


### PR DESCRIPTION
I don't know how to test this, but it is hopefully close as I copied off the previous versions. 

This adds a way for a user-generated pod to ask for minio credential injection.  The use case I'm working with that benefits is when using PyTorchJobs or TFJobs.  Without this, I don't know of an easy way to use minio from the jobs (users could add the right vault annotations, but they'd have to keep it in sync with what is done here).  

If we wanted, this could also be a pattern for future development.  Rather than having to teach this injector about new minio credential consumers, pods can just ask for them as needed.

That assumes there's no security reason to avoid this pattern.